### PR TITLE
Removes Unnecessary Repo Handlers That Actually Break Things

### DIFF
--- a/src/main/java/babric/BabricRepositoryHandler.java
+++ b/src/main/java/babric/BabricRepositoryHandler.java
@@ -44,11 +44,11 @@ public class BabricRepositoryHandler implements Plugin<PluginAware> {
             repo.setName("Babric");
             repo.setUrl(Constants.BABRIC_MAVEN);
         });
-        repositories.maven(repo -> { // No filter, all parts of this repo are used in a project.
+        repositories.maven(repo -> {
             repo.setName("Modrinth");
-            repo.setUrl(Constants.MODRINTH_MAVEN);
+            repo.setUrl(Constants.GLASS_MAVEN);
             repo.content(content -> {
-                content.includeModule("maven.modrinth", "gambac"); // Allow only gambac, don't let folk rely on this adding MR for them.
+                content.includeModule("net.danygames2014", "gambac"); // Allow only gambac, don't let folk rely on this adding MR for them.
             });
         });
     }

--- a/src/main/java/babric/Constants.java
+++ b/src/main/java/babric/Constants.java
@@ -3,5 +3,5 @@ package babric;
 public class Constants {
     public static final String LEGACYFABRIC_MAVEN = "https://repo.legacyfabric.net/repository/legacyfabric/";
     public static final String BABRIC_MAVEN = "https://maven.glass-launcher.net/babric/";
-    public static final String MODRINTH_MAVEN = "https://api.modrinth.com/maven/";
+    public static final String GLASS_MAVEN = "https://maven.glass-launcher.net/releases/";
 }

--- a/src/main/java/babric/processor/GambacLibraryProcessor.java
+++ b/src/main/java/babric/processor/GambacLibraryProcessor.java
@@ -49,7 +49,7 @@ public class GambacLibraryProcessor extends LibraryProcessor {
         if (!applied) {
             applied = true;
 
-            dependencyConsumer.accept(Library.fromMaven("maven.modrinth:gambac:" + VERSION, Library.Target.LOCAL_MOD));
+            dependencyConsumer.accept(Library.fromMaven("net.danygames2014:gambac:" + VERSION, Library.Target.LOCAL_MOD));
         }
 
         return ALLOW_ALL;

--- a/src/main/java/babric/processor/GambacLibraryProcessor.java
+++ b/src/main/java/babric/processor/GambacLibraryProcessor.java
@@ -54,14 +54,4 @@ public class GambacLibraryProcessor extends LibraryProcessor {
 
         return ALLOW_ALL;
     }
-
-    @Override
-    public void applyRepositories(RepositoryHandler repositories) {
-        repositories.exclusiveContent(repository -> {
-            repository.forRepositories(repositories.findByName("Modrinth"));
-            repository.filter(filter -> {
-                filter.includeModule("maven.modrinth", "gambac"); // Allow only gambac, don't let folk rely on this adding MR for them.
-            });
-        });
-    }
 }

--- a/src/main/java/babric/processor/LWJGL2LibraryProcessor.java
+++ b/src/main/java/babric/processor/LWJGL2LibraryProcessor.java
@@ -50,16 +50,6 @@ public class LWJGL2LibraryProcessor extends LibraryProcessor {
         };
     }
 
-    @Override
-    public void applyRepositories(RepositoryHandler repositories) {
-        repositories.exclusiveContent(repository -> {
-            repository.forRepositories(repositories.findByName("Legacy Fabric"));
-            repository.filter(filter -> {
-                filter.includeGroup("org.lwjgl.lwjgl");
-            });
-        });
-    }
-
     public static String getNativeClassifier() {
         switch (Platform.CURRENT.getOperatingSystem()) {
             case MAC_OS -> {


### PR DESCRIPTION
Don't ask why or how. I removed them, and gambac now properly gets added on projects outside of the test mod in this repo.

Tested on the crapbook.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/0de6aaa6-6ef4-4243-80d1-1f524c090c3a">
