### PR TITLE
Update Gambac to Latest Version

### DIFF
--- a/src/main/java/babric/processor/GambacLibraryProcessor.java
+++ b/src/main/java/babric/processor/GambacLibraryProcessor.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 public class GambacLibraryProcessor extends LibraryProcessor {
-    public static final String VERSION = "1.1.0";
+    public static final String VERSION = "1.1.1";
     private boolean applied = false;
     private final LoomGradleExtensionAPI loom;
     private final Project project;


### PR DESCRIPTION
Tin, fixes a bug where minecraft can duplicate it's screen when crashing on load.