### PR TITLE
Use system theme when on macOS

### DIFF
--- a/src/main/java/babric/BabricLoomPlugin.java
+++ b/src/main/java/babric/BabricLoomPlugin.java
@@ -11,6 +11,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.internal.os.OperatingSystem;
 
 import java.util.Map;
 import java.util.Objects;
@@ -46,5 +47,16 @@ public class BabricLoomPlugin implements Plugin<PluginAware> {
         });
 
         extension.addMinecraftJarProcessor(NestFixingJarProcessor.class);
+
+        project.afterEvaluate(p -> {
+            if (OperatingSystem.current().isMacOsX()) {
+                extension.getRunConfigs().configureEach(runConfig -> {
+                    System.out.println(runConfig);
+                    if (runConfig.getName().equals("client")) {
+                        runConfig.getVmArgs().add("-Dapple.awt.application.appearance=system");
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/main/java/babric/BabricLoomPlugin.java
+++ b/src/main/java/babric/BabricLoomPlugin.java
@@ -51,7 +51,6 @@ public class BabricLoomPlugin implements Plugin<PluginAware> {
         project.afterEvaluate(p -> {
             if (OperatingSystem.current().isMacOsX()) {
                 extension.getRunConfigs().configureEach(runConfig -> {
-                    System.out.println(runConfig);
                     if (runConfig.getName().equals("client")) {
                         runConfig.getVmArgs().add("-Dapple.awt.application.appearance=system");
                     }


### PR DESCRIPTION
regardless of using eclipse/idea runs or gradlew runClient this tells java to respect the theme of MacOS (light/dark) in dev env, see below
<img width="857" alt="image" src="https://github.com/user-attachments/assets/bf00b0ed-aadd-42f9-bf74-4d7a249458f3">
