### PR TITLE
Fix Legacyfabric Maven URL

### DIFF
--- a/src/main/java/babric/Constants.java
+++ b/src/main/java/babric/Constants.java
@@ -1,7 +1,7 @@
 package babric;
 
 public class Constants {
-    public static final String LEGACYFABRIC_MAVEN = "https://repo.legacyfabric.net/repository/legacyfabric/";
+    public static final String LEGACYFABRIC_MAVEN = "https://repo.legacyfabric.net/legacyfabric/";
     public static final String BABRIC_MAVEN = "https://maven.glass-launcher.net/babric/";
     public static final String GLASS_MAVEN = "https://maven.glass-launcher.net/releases/";
 }


### PR DESCRIPTION
Why did they change this without proper warning, whyyy